### PR TITLE
Prepare 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.2.0 – 2024-10-15
+
+### Fixed
+
+- Use correct zammad URLs in the backend
+
 ## [2.1.0] - 2024-07-25
 
 ### New

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<summary>Integration of Zammad user support/ticketing solution</summary>
 	<description><![CDATA[Zammad integration provides a dashboard widget displaying your important notifications,
 	a search provider for tickets and notifications for new open tickets.]]></description>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Zammad</namespace>


### PR DESCRIPTION
### Fixed

- Use correct zammad URLs in the backend